### PR TITLE
Better listing of incomplete refills

### DIFF
--- a/qml/pages/TankView.qml
+++ b/qml/pages/TankView.qml
@@ -76,7 +76,7 @@ Page {
                     width: parent.width
 
                     Text {
-                        text: model.modelData.distance + ((model.modelData.consumption > 0)?(qsTr("km (+") + model.modelData.newDistance+qsTr("km)")):(qsTr("km")));
+                        text: model.modelData.distance + ((model.modelData.newDistance > 0)?(qsTr("km (+") + model.modelData.newDistance+qsTr("km)")):(qsTr("km")));
 
                         font.family: Theme.fontFamily
                         font.pixelSize: Theme.fontSizeSmall

--- a/tank.cpp
+++ b/tank.cpp
@@ -90,16 +90,24 @@ void Tank::setFull(bool full)
 double Tank::consumption() const
 {
     const Tank *previous = _car->previousTank(_distance);
+    double quant = this->quantity();
+
+    if((previous == NULL) || (!full()))
+        return 0;
+    while((previous != NULL) && (!(previous->full()))) {
+        quant += previous->quantity();
+        previous = _car->previousTank(previous->distance());
+    }
     if(previous == NULL)
         return 0;
-    return _quantity / ((_distance - previous->distance()) / 100.0);
+    return quant / ((_distance - previous->distance()) / 100.0);
 }
 
 unsigned int Tank::newDistance() const
 {
     const Tank *previous = _car->previousTank(_distance);
     if(previous == NULL)
-        return _distance;
+        return 0;
     return _distance - previous->distance();
 }
 


### PR DESCRIPTION
Currently consumptions are computed even for non-full refills as if they
were full refills. This just skips non-full refills and displays average
consumption only on full refills.
