### PR TITLE
 display distance in configured units, store in km (WIP)

### DIFF
--- a/qml/pages/CarEntry.qml
+++ b/qml/pages/CarEntry.qml
@@ -26,6 +26,20 @@ import Sailfish.Silica 1.0
 Page {
     id: carEntry
     allowedOrientations: Orientation.All
+    property string distanceunit
+    property real distanceunitfactor
+
+    Component.onCompleted: {
+        distanceunit = manager.car.distanceunity
+        if(distanceunit == "km")
+        {
+            distanceunitfactor = 1
+        }
+        else if(distanceunit == "mi")
+        {
+            distanceunitfactor = 1.609
+        }
+    }
 
     // To enable PullDownMenu, place our content in a SilicaFlickable
     SilicaFlickable {
@@ -65,7 +79,7 @@ Page {
 
             Label {
                 x: Theme.paddingLarge
-                text: qsTr("Distance: %L1 ~ %L2 %3").arg(manager.car.mindistance).arg(manager.car.maxdistance).arg(manager.car.distanceunity)
+                text: qsTr("Distance: %L1 ~ %L2 %3").arg(manager.car.mindistance/distanceunitfactor).arg(manager.car.maxdistance/distanceunitfactor).arg(manager.car.distanceunity)
                 font.pixelSize: Theme.fontSizeSmall
             }
 

--- a/qml/pages/CarEntry.qml
+++ b/qml/pages/CarEntry.qml
@@ -79,7 +79,7 @@ Page {
 
             Label {
                 x: Theme.paddingLarge
-                text: qsTr("Distance: %L1 ~ %L2 %3").arg(manager.car.mindistance/distanceunitfactor).arg(manager.car.maxdistance/distanceunitfactor).arg(manager.car.distanceunity)
+                text: qsTr("Distance: %L1 ~ %L2 %3").arg((manager.car.mindistance/distanceunitfactor).toFixed(0)).arg((manager.car.maxdistance/distanceunitfactor).toFixed(0)).arg(manager.car.distanceunity)
                 font.pixelSize: Theme.fontSizeSmall
             }
 

--- a/qml/pages/TankEntry.qml
+++ b/qml/pages/TankEntry.qml
@@ -28,6 +28,8 @@ Dialog {
     property date tank_date
     property int station
     property int fueltype
+    property string distanceunit
+    property real distanceunitfactor
     allowedOrientations: Orientation.All
     SilicaFlickable {
         PullDownMenu {
@@ -190,10 +192,19 @@ Dialog {
     canAccept: kminput.acceptableInput && quantityinput.acceptableInput && priceinput.acceptableInput
 
     onOpened: {
+        distanceunit = manager.car.distanceunity
+        if(distanceunit == "km")
+        {
+            distanceunitfactor = 1
+        }
+        else if(distanceunit == "mi" )
+        {
+            distanceunitfactor = 1.609
+        }
         if(tank != undefined)
         {
             tank_date = tank.date
-            kminput.text = tank.distance
+            kminput.text = tank.distance / distanceunitfactor
             quantityinput.text = tank.quantity
             priceinput.text = tank.price
             fullinput.checked = tank.full
@@ -223,12 +234,12 @@ Dialog {
     onAccepted: {
         if(tank == undefined)
         {
-            manager.car.addNewTank(tank_date,kminput.text,quantityinput.text.replace(",","."),priceinput.text.replace(",","."),fullinput.checked, fueltype, station, noteinput.text)
+            manager.car.addNewTank(tank_date,kminput.text * distanceunitfactor,quantityinput.text.replace(",","."),priceinput.text.replace(",","."),fullinput.checked, fueltype, station, noteinput.text)
         }
         else
         {
             tank.date = tank_date
-            tank.distance = kminput.text
+            tank.distance = kminput.text * distanceunitfactor
             tank.quantity = quantityinput.text.replace(",",".")
             tank.price = priceinput.text.replace(",",".")
             tank.full = fullinput.checked

--- a/qml/pages/TankEntry.qml
+++ b/qml/pages/TankEntry.qml
@@ -204,7 +204,7 @@ Dialog {
         if(tank != undefined)
         {
             tank_date = tank.date
-            kminput.text = tank.distance / distanceunitfactor
+            kminput.text = (tank.distance / distanceunitfactor).toFixed(0)
             quantityinput.text = tank.quantity
             priceinput.text = tank.price
             fullinput.checked = tank.full

--- a/qml/pages/TankEntryView.qml
+++ b/qml/pages/TankEntryView.qml
@@ -106,7 +106,7 @@ Page {
 					width:(parent.width-parent.spacing)/2
 				}
 				Text {
-					text: tank.distance/distanceunitfactor
+                    text: (tank.distance/distanceunitfactor).toFixed(0)
 					font.family: Theme.fontFamily
 					font.pixelSize: Theme.fontSizeMedium
 					color: Theme.primaryColor

--- a/qml/pages/TankEntryView.qml
+++ b/qml/pages/TankEntryView.qml
@@ -26,6 +26,21 @@ import harbour.carbudget 1.0
 Page {
         allowedOrientations: Orientation.All
         property Tank tank
+        property string distanceunit
+        property real distanceunitfactor
+
+        Component.onCompleted: {
+            distanceunit = manager.car.distanceunity
+            if(distanceunit == "km")
+            {
+                distanceunitfactor = 1
+            }
+            else if(distanceunit == "mi")
+            {
+                distanceunitfactor = 1.609
+            }
+        }
+
 
         SilicaFlickable {
 
@@ -91,7 +106,7 @@ Page {
 					width:(parent.width-parent.spacing)/2
 				}
 				Text {
-					text: tank.distance
+					text: tank.distance/distanceunitfactor
 					font.family: Theme.fontFamily
 					font.pixelSize: Theme.fontSizeMedium
 					color: Theme.primaryColor

--- a/qml/pages/TankView.qml
+++ b/qml/pages/TankView.qml
@@ -27,6 +27,21 @@ import harbour.carbudget 1.0
 Page {
     property string filter: ""
     allowedOrientations: Orientation.All
+    property string distanceunit
+    property real distanceunitfactor
+
+    Component.onCompleted: {
+        distanceunit = manager.car.distanceunity
+        if(distanceunit == "km")
+        {
+            distanceunitfactor = 1
+        }
+        else if(distanceunit == "mi")
+        {
+            distanceunitfactor = 1.609
+        }
+    }
+
     Drawer {
         id: tankviewDrawer
         anchors.fill: parent
@@ -100,7 +115,7 @@ Page {
                         width: parent.width
 
                         Text {
-                            text: model.modelData.distance + ((model.modelData.newDistance > 0)?(manager.car.distanceunity + " (+" + model.modelData.newDistance+manager.car.distanceunity+")"):(manager.car.distanceunity));
+                            text: model.modelData.distance/distanceunitfactor + ((model.modelData.newDistance > 0)?(manager.car.distanceunity + " (+" + model.modelData.newDistance/distanceunitfactor+manager.car.distanceunity+")"):(manager.car.distanceunity));
 
                             font.family: Theme.fontFamily
                             font.pixelSize: Theme.fontSizeSmall

--- a/qml/pages/TankView.qml
+++ b/qml/pages/TankView.qml
@@ -115,7 +115,7 @@ Page {
                         width: parent.width
 
                         Text {
-                            text: model.modelData.distance/distanceunitfactor + ((model.modelData.newDistance > 0)?(manager.car.distanceunity + " (+" + model.modelData.newDistance/distanceunitfactor+manager.car.distanceunity+")"):(manager.car.distanceunity));
+                            text: (model.modelData.distance/distanceunitfactor).toFixed(0) + ((model.modelData.newDistance > 0)?(manager.car.distanceunity + " (+" + (model.modelData.newDistance/distanceunitfactor).toFixed(0)+manager.car.distanceunity+")"):(manager.car.distanceunity));
 
                             font.family: Theme.fontFamily
                             font.pixelSize: Theme.fontSizeSmall


### PR DESCRIPTION
As mentioned in #31, I would like to be able to be more flexible in how the data is displayed. As far as I see it, fuelpad for maemo was flexible in that. Fuelpad stores all distances in the database in km and re-calculates on the fly during entering the data and again during display. This patchset starts implementing this for carbudget (initial only for tank entries).

Note that this is very much WIP and most likely not the best way to achieve the goal by a long way, but as I started working on it, I think this might be a good way to start a discussion. (For example the current way of setting the conversion factors in every QML file is hopefully something that can be improved, but then my QML fu is limited right now and this was a quick way to see if it works at all.)

Implemented so far is the ability to enter and display data in miles for tank entries, while have it stored in km. 