### PR TITLE
Store distances in km, enter in mi (part 2)

### DIFF
--- a/qml/pages/BudgetView.qml
+++ b/qml/pages/BudgetView.qml
@@ -27,6 +27,21 @@ import harbour.carbudget 1.0
 Page {
     allowedOrientations: Orientation.All
     id: budgetPage
+    property string distanceunit
+    property real distanceunitfactor
+
+    Component.onCompleted: {
+        distanceunit = manager.car.distanceunity
+        if(distanceunit == "km")
+        {
+            distanceunitfactor = 1
+        }
+        else if(distanceunit == "mi")
+        {
+            distanceunitfactor = 1.609
+        }
+    }
+
     Drawer {
         id: budgetviewDrawer
         anchors.fill: parent
@@ -200,7 +215,7 @@ Page {
                 }
                 Text {
                     width:parent.width/2
-                    text :  manager.car.maxdistance
+                    text :  (manager.car.maxdistance/distanceunitfactor).toFixed(0)
                     font.family: "monospaced"
                     font.pixelSize: Theme.fontSizeSmall
                     color: Theme.primaryColor
@@ -219,7 +234,7 @@ Page {
                 }
                 Text {
                     width:parent.width/2
-                    text :  manager.car.maxdistance - manager.car.mindistance
+                    text :  ((manager.car.maxdistance - manager.car.mindistance)/distanceunitfactor).toFixed(0)
                     font.family: "monospaced"
                     font.pixelSize: Theme.fontSizeSmall
                     color: Theme.primaryColor

--- a/qml/pages/BudgetView.qml
+++ b/qml/pages/BudgetView.qml
@@ -28,15 +28,11 @@ Page {
     allowedOrientations: Orientation.All
     id: budgetPage
     property string distanceunit
-    property real distanceunitfactor
+    property real distanceunitfactor: 1
 
     Component.onCompleted: {
         distanceunit = manager.car.distanceunity
-        if(distanceunit == "km")
-        {
-            distanceunitfactor = 1
-        }
-        else if(distanceunit == "mi")
+        if(distanceunit == "mi")
         {
             distanceunitfactor = 1.609
         }

--- a/qml/pages/CarEntry.qml
+++ b/qml/pages/CarEntry.qml
@@ -27,15 +27,11 @@ Page {
     id: carEntry
     allowedOrientations: Orientation.All
     property string distanceunit
-    property real distanceunitfactor
+    property real distanceunitfactor: 1
 
     Component.onCompleted: {
         distanceunit = manager.car.distanceunity
-        if(distanceunit == "km")
-        {
-            distanceunitfactor = 1
-        }
-        else if(distanceunit == "mi")
+        if(distanceunit == "mi")
         {
             distanceunitfactor = 1.609
         }

--- a/qml/pages/CostEntry.qml
+++ b/qml/pages/CostEntry.qml
@@ -28,7 +28,7 @@ Dialog {
     property date cost_date
     property int costtype
     property string distanceunit
-    property real distanceunitfactor
+    property real distanceunitfactor: 1
     allowedOrientations: Orientation.All
     SilicaFlickable {
         PullDownMenu {
@@ -133,11 +133,7 @@ Dialog {
 
     onOpened: {
         distanceunit = manager.car.distanceunity
-        if(distanceunit == "km")
-        {
-            distanceunitfactor = 1
-        }
-        else if(distanceunit == "mi" )
+        if(distanceunit == "mi" )
         {
             distanceunitfactor = 1.609
         }

--- a/qml/pages/CostEntry.qml
+++ b/qml/pages/CostEntry.qml
@@ -27,6 +27,8 @@ Dialog {
     property Cost cost
     property date cost_date
     property int costtype
+    property string distanceunit
+    property real distanceunitfactor
     allowedOrientations: Orientation.All
     SilicaFlickable {
         PullDownMenu {
@@ -130,10 +132,19 @@ Dialog {
     canAccept: kminput.acceptableInput && costinput.acceptableInput
 
     onOpened: {
+        distanceunit = manager.car.distanceunity
+        if(distanceunit == "km")
+        {
+            distanceunitfactor = 1
+        }
+        else if(distanceunit == "mi" )
+        {
+            distanceunitfactor = 1.609
+        }
         if(cost != undefined)
         {
             cost_date = cost.date
-            kminput.text = cost.distance
+            kminput.text = (cost.distance / distanceunitfactor)
             costtype = cost.costtype
             descinput.text = cost.description
             costinput.text = cost.cost
@@ -152,12 +163,12 @@ Dialog {
     onAccepted: {
         if(cost == undefined)
         {
-            manager.car.addNewCost(cost_date,kminput.text,costtype,descinput.text,costinput.text.replace(",","."))
+            manager.car.addNewCost(cost_date,kminput.text * distanceunitfactor,costtype,descinput.text,costinput.text.replace(",","."))
         }
         else
         {
             cost.date = cost_date
-            cost.distance = kminput.text
+            cost.distance = kminput.text * distanceunitfactor
             cost.costtype = costtype
             cost.description = descinput.text
             cost.cost = costinput.text.replace(",",".")

--- a/qml/pages/CostEntryView.qml
+++ b/qml/pages/CostEntryView.qml
@@ -26,6 +26,21 @@ import harbour.carbudget 1.0
 Page {
         allowedOrientations: Orientation.All
         property Cost cost
+    property string distanceunit
+    property real distanceunitfactor
+
+    Component.onCompleted: {
+        distanceunit = manager.car.distanceunity
+        if(distanceunit == "km")
+        {
+            distanceunitfactor = 1
+        }
+        else if(distanceunit == "mi")
+        {
+            distanceunitfactor = 1.609
+        }
+    }
+
 
         SilicaFlickable {
 
@@ -62,7 +77,7 @@ Page {
                         width:(parent.width-parent.spacing)/2
                     }
                     Text {
-                        text: cost.distance
+                        text: (cost.distance/distanceunitfactor).toFixed(0)
                         font.family: Theme.fontFamily
                         font.pixelSize: Theme.fontSizeMedium
                         color: Theme.primaryColor

--- a/qml/pages/CostEntryView.qml
+++ b/qml/pages/CostEntryView.qml
@@ -27,15 +27,11 @@ Page {
         allowedOrientations: Orientation.All
         property Cost cost
     property string distanceunit
-    property real distanceunitfactor
+    property real distanceunitfactor: 1
 
     Component.onCompleted: {
         distanceunit = manager.car.distanceunity
-        if(distanceunit == "km")
-        {
-            distanceunitfactor = 1
-        }
-        else if(distanceunit == "mi")
+        if(distanceunit == "mi")
         {
             distanceunitfactor = 1.609
         }

--- a/qml/pages/CostView.qml
+++ b/qml/pages/CostView.qml
@@ -28,15 +28,11 @@ Page {
     property bool showDescription: false
     allowedOrientations: Orientation.All
     property string distanceunit
-    property real distanceunitfactor
+    property real distanceunitfactor: 1
 
     Component.onCompleted: {
         distanceunit = manager.car.distanceunity
-        if(distanceunit == "km")
-        {
-            distanceunitfactor = 1
-        }
-        else if(distanceunit == "mi")
+        if(distanceunit == "mi")
         {
             distanceunitfactor = 1.609
         }

--- a/qml/pages/CostView.qml
+++ b/qml/pages/CostView.qml
@@ -27,6 +27,21 @@ Page {
     // When in statistics drilldown, show description instead of cost type
     property bool showDescription: false
     allowedOrientations: Orientation.All
+    property string distanceunit
+    property real distanceunitfactor
+
+    Component.onCompleted: {
+        distanceunit = manager.car.distanceunity
+        if(distanceunit == "km")
+        {
+            distanceunitfactor = 1
+        }
+        else if(distanceunit == "mi")
+        {
+            distanceunitfactor = 1.609
+        }
+    }
+
     Drawer {
         id: costviewDrawer
         anchors.fill: parent
@@ -90,7 +105,7 @@ Page {
                     Row {
                         width: parent.width
                         Text {
-                            text: model.modelData.distance + manager.car.distanceunity;
+                            text: (model.modelData.distance/distanceunitfactor).toFixed(0) + manager.car.distanceunity;
                             font.family: Theme.fontFamily
                             font.pixelSize: Theme.fontSizeSmall
                             color: Theme.primaryColor

--- a/qml/pages/TankEntry.qml
+++ b/qml/pages/TankEntry.qml
@@ -29,7 +29,7 @@ Dialog {
     property int station
     property int fueltype
     property string distanceunit
-    property real distanceunitfactor
+    property real distanceunitfactor: 1
     allowedOrientations: Orientation.All
     SilicaFlickable {
         PullDownMenu {
@@ -193,11 +193,7 @@ Dialog {
 
     onOpened: {
         distanceunit = manager.car.distanceunity
-        if(distanceunit == "km")
-        {
-            distanceunitfactor = 1
-        }
-        else if(distanceunit == "mi" )
+        if(distanceunit == "mi" )
         {
             distanceunitfactor = 1.609
         }

--- a/qml/pages/TankEntryView.qml
+++ b/qml/pages/TankEntryView.qml
@@ -27,15 +27,11 @@ Page {
         allowedOrientations: Orientation.All
         property Tank tank
         property string distanceunit
-        property real distanceunitfactor
+        property real distanceunitfactor: 1
 
         Component.onCompleted: {
             distanceunit = manager.car.distanceunity
-            if(distanceunit == "km")
-            {
-                distanceunitfactor = 1
-            }
-            else if(distanceunit == "mi")
+            if(distanceunit == "mi")
             {
                 distanceunitfactor = 1.609
             }

--- a/qml/pages/TankView.qml
+++ b/qml/pages/TankView.qml
@@ -28,15 +28,11 @@ Page {
     property string filter: ""
     allowedOrientations: Orientation.All
     property string distanceunit
-    property real distanceunitfactor
+    property real distanceunitfactor : 1.0
 
     Component.onCompleted: {
         distanceunit = manager.car.distanceunity
-        if(distanceunit == "km")
-        {
-            distanceunitfactor = 1
-        }
-        else if(distanceunit == "mi")
+        if(distanceunit == "mi")
         {
             distanceunitfactor = 1.609
         }

--- a/qml/pages/TireMount.qml
+++ b/qml/pages/TireMount.qml
@@ -89,11 +89,7 @@ Dialog {
 
     onAccepted: {
         distanceunit = manager.car.distanceunity
-        if(distanceunit == "km")
-        {
-            distanceunitfactor = 1
-        }
-        else if(distanceunit == "mi" )
+        if(distanceunit == "mi" )
         {
             distanceunitfactor = 1.609
         }

--- a/qml/pages/TireMount.qml
+++ b/qml/pages/TireMount.qml
@@ -88,9 +88,18 @@ Dialog {
     }
 
     onAccepted: {
+        distanceunit = manager.car.distanceunity
+        if(distanceunit == "km")
+        {
+            distanceunitfactor = 1
+        }
+        else if(distanceunit == "mi" )
+        {
+            distanceunitfactor = 1.609
+        }
         if(tire.mounted)
-            manager.car.umountTire(mount_date, kminput.text, tire, totrashinput.checked)
+            manager.car.umountTire(mount_date, kminput.text * distanceunitfactor, tire, totrashinput.checked)
         else
-            manager.car.mountTire(mount_date, kminput.text, tire)
+            manager.car.mountTire(mount_date, kminput.text * distanceunitfactor, tire)
     }
 }

--- a/qml/pages/TireView.qml
+++ b/qml/pages/TireView.qml
@@ -26,15 +26,11 @@ import harbour.carbudget 1.0
 Page {
     allowedOrientations: Orientation.All
     property string distanceunit
-    property real distanceunitfactor
+    property real distanceunitfactor: 1
 
     Component.onCompleted: {
         distanceunit = manager.car.distanceunity
-        if(distanceunit == "km")
-        {
-            distanceunitfactor = 1
-        }
-        else if(distanceunit == "mi")
+        if(distanceunit == "mi")
         {
             distanceunitfactor = 1.609
         }

--- a/qml/pages/TireView.qml
+++ b/qml/pages/TireView.qml
@@ -25,6 +25,21 @@ import harbour.carbudget 1.0
 
 Page {
     allowedOrientations: Orientation.All
+    property string distanceunit
+    property real distanceunitfactor
+
+    Component.onCompleted: {
+        distanceunit = manager.car.distanceunity
+        if(distanceunit == "km")
+        {
+            distanceunitfactor = 1
+        }
+        else if(distanceunit == "mi")
+        {
+            distanceunitfactor = 1.609
+        }
+    }
+
     SilicaListView {
         PullDownMenu {
             MenuItem {
@@ -83,7 +98,7 @@ Page {
                     width: parent.width
 
                     Text {
-                        text: model.modelData.manufacturer + " (" + model.modelData.distance + manager.car.distanceunity + ")";
+                        text: model.modelData.manufacturer + " (" + (model.modelData.distance/distanceunitfactor).toFixed(0) + manager.car.distanceunity + ")";
                         font.bold: model.modelData.mounted
 
                         font.family: Theme.fontFamily

--- a/qml/pages/TiremountEdit.qml
+++ b/qml/pages/TiremountEdit.qml
@@ -111,11 +111,7 @@ Dialog {
 
     onOpened: {
         distanceunit = manager.car.distanceunity
-        if(distanceunit == "km")
-        {
-            distanceunitfactor = 1
-        }
-        else if(distanceunit == "mi" )
+        if(distanceunit == "mi" )
         {
             distanceunitfactor = 1.609
         }

--- a/qml/pages/TiremountEdit.qml
+++ b/qml/pages/TiremountEdit.qml
@@ -110,12 +110,21 @@ Dialog {
     canAccept: mountdistance.acceptableInput && unmountdistance.acceptableInput
 
     onOpened: {
+        distanceunit = manager.car.distanceunity
+        if(distanceunit == "km")
+        {
+            distanceunitfactor = 1
+        }
+        else if(distanceunit == "mi" )
+        {
+            distanceunitfactor = 1.609
+        }
         if(tiremount != undefined)
         {
             mountdate = tiremount.mountdate
-            mountdistance.text = tiremount.mountdistance
+            mountdistance.text = (tiremount.mountdistance / distanceunitfactor).toFixed(0)
             unmountdate = tiremount.unmountdate
-            unmountdistance.text = tiremount.unmountdistance
+            unmountdistance.text = (tiremount.unmountdistance / distanceunitfactor).toFixed(0)
             if (tiremount.unmountdistance==0)
             {
                 unmountdistance.visible=false;
@@ -131,11 +140,11 @@ Dialog {
     }
     onAccepted: {
         tiremount.mountdate = mountdate
-        tiremount.mountdistance = mountdistance.text
+        tiremount.mountdistance = mountdistance.text * distanceunitfactor
         if (tiremount.unmountdistance > 0)
         {
             tiremount.unmountdate = unmountdate
-            tiremount.unmountdistance = unmountdistance.text
+            tiremount.unmountdistance = unmountdistance.text * distanceunitfactor
         }
         tiremount.save()
     }

--- a/qml/pages/TiremountView.qml
+++ b/qml/pages/TiremountView.qml
@@ -25,15 +25,11 @@ import harbour.carbudget 1.0
 Page {
     allowedOrientations: Orientation.All
     property string distanceunit
-    property real distanceunitfactor
+    property real distanceunitfactor: 1
 
     Component.onCompleted: {
         distanceunit = manager.car.distanceunity
-        if(distanceunit == "km")
-        {
-            distanceunitfactor = 1
-        }
-        else if(distanceunit == "mi")
+        if(distanceunit == "mi")
         {
             distanceunitfactor = 1.609
         }

--- a/qml/pages/TiremountView.qml
+++ b/qml/pages/TiremountView.qml
@@ -24,6 +24,21 @@ import harbour.carbudget 1.0
 
 Page {
     allowedOrientations: Orientation.All
+    property string distanceunit
+    property real distanceunitfactor
+
+    Component.onCompleted: {
+        distanceunit = manager.car.distanceunity
+        if(distanceunit == "km")
+        {
+            distanceunitfactor = 1
+        }
+        else if(distanceunit == "mi")
+        {
+            distanceunitfactor = 1.609
+        }
+    }
+
     Drawer {
         id: tiremountviewDrawer
         anchors.fill: parent
@@ -82,7 +97,7 @@ Page {
                      Row {
                         width: parent.width
                         Text {
-                            text: model.modelData.mountdistance + manager.car.distanceunity + ((model.modelData.unmountdistance==0) ? "" :  " - " + model.modelData.unmountdistance + manager.car.distanceunity)
+                            text: (model.modelData.mountdistance/distanceunitfactor).toFixed(0) + manager.car.distanceunity + ((model.modelData.unmountdistance==0) ? "" :  " - " + (model.modelData.unmountdistance/distanceunitfactor).toFixed(0) + manager.car.distanceunity)
                             font.family: Theme.fontFamily
                             font.pixelSize: Theme.fontSizeExtraSmall
                             color: Theme.primaryColor


### PR DESCRIPTION
Depending on the setting, displayed distance units are either km or mi, handle
neccessary conversion within QML so that data stored in the database is always
in km.

This handling is similar to what fuelpad (on maemo) did and should later allow
more flexibility when displaying various statistics like consumption etc.

This patch implements this for tire information, cost entries and in the budget
overview page.

This should move us slightly close to resolving #31 and completes the pages I found where distances are handled. (There are still a few items in the budget view pages where costs appear to be shown in cost/100km but on initial checking, I'm not sure what these are and how they are handled, so I ignored them for now.)