### PR TITLE
allow user to choose unit to display for consumption

### DIFF
--- a/car.cpp
+++ b/car.cpp
@@ -1476,6 +1476,47 @@ void Car::setBuyingdate(QDate date)
     emit buyingdateChanged();
 }
 
+QString Car::consumptionunit()
+{
+    if (_consumptionunit.length() < 1)
+    {
+        QSqlQuery query(this->db);
+
+        if(query.exec("SELECT value FROM CarBudget WHERE id='consumptionunit';"))
+        {
+            query.next();
+            _consumptionunit = query.value(0).toString();
+            qDebug() << "Find consumptionunit in database: " << _consumptionunit;
+        }
+        if(_consumptionunit.length() < 1)
+        {
+            qDebug() << "Default consumptionunit not set in database, set to l/100km";
+            query.exec("INSERT INTO CarBudget (id, value) VALUES ('consumptionunit', 'l/100km');");
+            _consumptionunit = "l/100km";
+        }
+    }
+
+    return _consumptionunit;
+}
+
+void Car::setConsumptionunit(QString consumptionunit)
+{
+    QSqlQuery query(this->db);
+
+    if(query.exec("SELECT count(*) FROM CarBudget WHERE id='consumptionunit';"))
+    {
+        query.next();
+        if(query.value(0).toString().toInt() < 1)
+            query.exec(QString("INSERT INFO CarBudget (id, value) VALUES ('consumptionunit','%1');").arg(consumptionunit));
+        else
+            query.exec(QString("UPDATE CarBudget SET value='%1' WHERE id='consumptionunit';").arg(consumptionunit));
+
+        qDebug() << "Change consumptionunit in database: " << _consumptionunit << " >> " << consumptionunit;
+    }
+    _consumptionunit = consumptionunit;
+    emit consumptionunitChanged();
+}
+
 void Car::simulation()
 {
     Tire *winter1, *winter2, *summer1;

--- a/car.h
+++ b/car.h
@@ -61,6 +61,7 @@ class Car : public QObject
     Q_PROPERTY(QString name READ getName NOTIFY nameChanged())
     Q_PROPERTY(QString currency READ currency WRITE setCurrency NOTIFY currencyChanged())
     Q_PROPERTY(QString distanceunity READ distanceunity WRITE setDistanceunity NOTIFY distanceunityChanged())
+    Q_PROPERTY(QString consumptionunit READ consumptionunit WRITE setConsumptionunit NOTIFY consumptionunitChanged())
     Q_PROPERTY(unsigned int nbtire READ nbtire WRITE setNbtire NOTIFY nbtireChanged)
     Q_PROPERTY(double buyingprice READ buyingprice WRITE setBuyingprice NOTIFY buyingpriceChanged)
     Q_PROPERTY(double sellingprice READ sellingprice WRITE setSellingprice NOTIFY sellingpriceChanged)
@@ -92,6 +93,7 @@ private:
 
     QString _currency;
     QString _distanceunity;
+    QString _consumptionunit;
 
     unsigned int _nbtire;
     double _buyingprice;
@@ -175,6 +177,7 @@ signals:
     void tireMountedChanged();
     void currencyChanged();
     void distanceunityChanged();
+    void consumptionunitChanged();
     void nbtireChanged();
     void sellingpriceChanged();
     void buyingpriceChanged();
@@ -217,6 +220,9 @@ public slots:
 
     QString distanceunity();
     void setDistanceunity(QString distanceunity);
+
+    QString consumptionunit();
+    void setConsumptionunit(QString consumptionunit);
 
     unsigned int nbtire();
     void setNbtire(unsigned int nbtire);

--- a/qml/pages/CarEntry.qml
+++ b/qml/pages/CarEntry.qml
@@ -38,7 +38,7 @@ Page {
         }
         if(manager.car.consumptionunit == 'mpg')
         {
-            consumptionfactor  = 4.5*100/1.609
+            consumptionfactor  = 4.546*100/1.609
         }
     }
 

--- a/qml/pages/CarEntry.qml
+++ b/qml/pages/CarEntry.qml
@@ -28,12 +28,17 @@ Page {
     allowedOrientations: Orientation.All
     property string distanceunit
     property real distanceunitfactor: 1
+    property real consumptionfactor : 1.0
 
     Component.onCompleted: {
         distanceunit = manager.car.distanceunity
         if(distanceunit == "mi")
         {
             distanceunitfactor = 1.609
+        }
+        if(manager.car.consumptionunit == 'mpg')
+        {
+            consumptionfactor  = 4.5*100/1.609
         }
     }
 
@@ -81,12 +86,24 @@ Page {
 
             Label {
                 x: Theme.paddingLarge
-                text: qsTr("Consumption: %L1 l/100km").arg(manager.car.consumption.toFixed(2))
+                text:
+          if ( manager.car.consumptionunit == 'l/100km' ) {
+			qsTr("Consumption: %L1 l/100km").arg(manager.car.consumption.toFixed(2))
+		  }
+          else if ( manager.car.consumptionunit == 'mpg' ) {
+			qsTr("Consumption: %L1 mpg").arg((consumptionfactor * 1/manager.car.consumption).toFixed(2))
+		  }
                 font.pixelSize: Theme.fontSizeSmall
             }
             Label {
                 x: Theme.paddingLarge
-                text: qsTr("Last: %L1 l/100km").arg(manager.car.consumptionlast.toFixed(2))
+                text:
+          if ( manager.car.consumptionunit == 'l/100km' ) {
+			qsTr("Last: %L1 l/100km").arg(manager.car.consumptionlast.toFixed(2))
+		  }
+          else if ( manager.car.consumptionunit == 'mpg' ) {
+			qsTr("Last: %L1 mpg").arg((consumptionfactor * 1/manager.car.consumptionlast).toFixed(2))
+		  }
                 font.pixelSize: Theme.fontSizeSmall
                 color: {
                     if(manager.car.consumptionlast < manager.car.consumption * 0.92) return "#00FF00"

--- a/qml/pages/CarEntry.qml
+++ b/qml/pages/CarEntry.qml
@@ -81,12 +81,12 @@ Page {
 
             Label {
                 x: Theme.paddingLarge
-                text: qsTr("Consumption: %L1 l/100%2").arg(manager.car.consumption.toFixed(2)).arg(manager.car.distanceunity)
+                text: qsTr("Consumption: %L1 l/100km").arg(manager.car.consumption.toFixed(2))
                 font.pixelSize: Theme.fontSizeSmall
             }
             Label {
                 x: Theme.paddingLarge
-                text: qsTr("Last: %L1 l/100%2").arg(manager.car.consumptionlast.toFixed(2)).arg(manager.car.distanceunity)
+                text: qsTr("Last: %L1 l/100km").arg(manager.car.consumptionlast.toFixed(2))
                 font.pixelSize: Theme.fontSizeSmall
                 color: {
                     if(manager.car.consumptionlast < manager.car.consumption * 0.92) return "#00FF00"

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -25,6 +25,7 @@ import harbour.carbudget 1.0
 
 Dialog {
     property date buying_date
+    property string consumptionunit
     allowedOrientations: Orientation.All
     SilicaFlickable {
 
@@ -66,6 +67,29 @@ Dialog {
                 EnterKey.onClicked: nbtire.focus = true
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
             }
+            ComboBox {
+                id: selectconsumptionunit
+                anchors { left: parent.left; right: parent.right }
+                focus: true
+                label: qsTr("Consumption Unit")
+
+                menu: ContextMenu {
+                    id: consumptionunitmenu
+
+                MenuItem {
+                    text: qsTr('l/100km')
+                    property string value: qsTr("l/100km")
+                }
+                MenuItem {
+                    text: qsTr('mpg')
+                    property string value: qsTr("mpg")
+                }
+                }
+                onCurrentItemChanged: {
+                        consumptionunit = currentItem.value
+                }
+            }
+
             TextField {
                 id: nbtire
                 anchors { left: parent.left; right: parent.right }
@@ -143,6 +167,17 @@ Dialog {
         buyingprice.text   = manager.car.buyingprice
         sellingprice.text  = manager.car.sellingprice
         lifetime.text      = manager.car.lifetime
+        consumptionunit = manager.car.consumptionunit
+        // I'm not sure why the next section sets the drop down menu list
+        // to the current value, I stole the idea of harbour-callrecorder
+        consumptionunitmenu._foreachMenuItem(function(item, index) {
+            if (item.value == consumptionunit)
+            {
+                selectconsumptionunit.currentIndex= index
+                return true
+            }
+            return true
+        })
     }
 
     onAccepted: {
@@ -153,5 +188,16 @@ Dialog {
         manager.car.buyingprice   = buyingprice.text
         manager.car.sellingprice  = sellingprice.text
         manager.car.lifetime      = lifetime.text
+        manager.car.consumptionunit = consumptionunit
     }
+    //onCompleted: {
+        //consumptionunitmenu._foreachMenuItem(function(item, index) {
+            //if (item.value == consumptionunit)
+            //{
+                //selectconsumptionunit.currentIndex= index
+                //return false
+            //}
+            //return true
+        //})
+    //}
 }

--- a/qml/pages/TankView.qml
+++ b/qml/pages/TankView.qml
@@ -29,12 +29,17 @@ Page {
     allowedOrientations: Orientation.All
     property string distanceunit
     property real distanceunitfactor : 1.0
+    property real consumptionfactor : 1.0
 
     Component.onCompleted: {
         distanceunit = manager.car.distanceunity
         if(distanceunit == "mi")
         {
             distanceunitfactor = 1.609
+        }
+        if(manager.car.consumptionunit == 'mpg')
+        {
+            consumptionfactor = 4.5*100/1.609
         }
     }
 
@@ -157,7 +162,15 @@ Page {
                             horizontalAlignment: Text.AlignRight
                         }
                         Text {
-                            text: model.modelData.consumption.toFixed(2)+ "l/100" + "km";
+                            text: if ( manager.car.consumptionunit == 'l/100km') {
+                                 model.modelData.consumption.toFixed(2)+ "l/100" + "km";
+                             }
+                            else {
+                                if ( manager.car.consumptionunit == 'mpg') {
+                                qsTr("%L1 mpg").arg((consumptionfactor * 1/model.modelData.consumption).toFixed(2))
+                            }
+                        }
+
                             visible: model.modelData.consumption > 0
                             font.family: Theme.fontFamily
                             font.pixelSize: Theme.fontSizeSmall

--- a/qml/pages/TankView.qml
+++ b/qml/pages/TankView.qml
@@ -157,7 +157,7 @@ Page {
                             horizontalAlignment: Text.AlignRight
                         }
                         Text {
-                            text: model.modelData.consumption.toFixed(2)+ "l/100" + manager.car.distanceunity;
+                            text: model.modelData.consumption.toFixed(2)+ "l/100" + "km";
                             visible: model.modelData.consumption > 0
                             font.family: Theme.fontFamily
                             font.pixelSize: Theme.fontSizeSmall

--- a/qml/pages/TankView.qml
+++ b/qml/pages/TankView.qml
@@ -39,7 +39,7 @@ Page {
         }
         if(manager.car.consumptionunit == 'mpg')
         {
-            consumptionfactor = 4.5*100/1.609
+            consumptionfactor = 4.546*100/1.609
         }
     }
 


### PR DESCRIPTION
In the UK it is still common to measure consumption in MPG (miles per (imperial) gallon).

This branch allows a user to select the unit to display the consumption between l/100km and mpg and does the conversion on the fly when displaying consumption.

This patch set basically completes the work I think we need to be able to close #31.
