### PR TITLE
Create intermediate directories along with dataDir

### DIFF
--- a/carmanager.cpp
+++ b/carmanager.cpp
@@ -34,7 +34,10 @@ void CarManager::refresh()
     if(!dataDir.exists())
     {
         qDebug() << "Creating data directory" << dataPath;
-        dataDir.mkdir(dataPath);
+        if(!dataDir.mkpath(dataPath))
+        {
+            qDebug() << "ERROR: failed to create data directory" << dataPath;
+        }
     }
 
     // Move (rename) *.cbg files from home directory to data directory.


### PR DESCRIPTION
While testing the latest code on  a fresh SailfishOS SDK (i.e. carbudget had never been installed an no other appilications had been installed in the emulator), I noticed that it wasn't possible to create a new car in carbudget. Turns out that the necessary directory was not created (and no error message to that respect). Replaced the mkdir() with mkpath() as the later will also create intermediate directories. Creating new cars on a fresh install now works.

(BTW: let me know if you prefer to have issues created for something like this before a pull request or if just a pull request is ok?)