### PR TITLE
Fix chart rendering, validators

### DIFF
--- a/qml/pages/BudgetView.qml
+++ b/qml/pages/BudgetView.qml
@@ -46,6 +46,11 @@ Page {
         }
     }
 
+    onVisibleChanged: {
+        if(visible == true)
+            pieChart.requestPaint()
+    }
+
     SilicaFlickable {
         anchors.fill: parent
         contentHeight: flowElement.height + header.height + Theme.paddingSmall

--- a/qml/pages/CarCreate.qml
+++ b/qml/pages/CarCreate.qml
@@ -48,7 +48,7 @@ Dialog {
                 focus: true
                 label: qsTr("Short car name")
                 placeholderText: label
-                validator: RegExpValidator { regExp: /^[0-9A-Za-z_]{4,16}$/ }
+                validator: RegExpValidator { regExp: /^[0-9A-Za-z_-]{4,16}$/ }
                 color: errorHighlight ? Theme.highlightColor : Theme.primaryColor
                 inputMethodHints: Qt.ImhNoPredictiveText
                 EnterKey.enabled: text.length > 0 && acceptableInput == true
@@ -60,7 +60,7 @@ Dialog {
                 width: parent.textWidth
                 label: qsTr("Car manufacturer")
                 placeholderText: label
-                validator: RegExpValidator { regExp: /^[0-9A-Za-z_]{1,32}$/ }
+                validator: RegExpValidator { regExp: /^[0-9A-Za-z_-]{1,32}$/ }
                 color: errorHighlight ? Theme.highlightColor : Theme.primaryColor
                 EnterKey.enabled: text.length > 0 && acceptableInput == true
                 EnterKey.onClicked: model.focus = true
@@ -71,7 +71,7 @@ Dialog {
                 width: parent.textWidth
                 label: qsTr("Car model")
                 placeholderText: label
-                validator: RegExpValidator { regExp: /^[0-9A-Za-z_]{1,32}$/ }
+                validator: RegExpValidator { regExp: /^[0-9A-Za-z_-]{1,32}$/ }
                 color: errorHighlight ? Theme.highlightColor : Theme.primaryColor
                 EnterKey.enabled: text.length > 0 && acceptableInput == true
                 EnterKey.onClicked: year.focus = true
@@ -85,14 +85,14 @@ Dialog {
                 validator: IntValidator { bottom: 1000; top: 9999 }
                 color: errorHighlight ? Theme.highlightColor : Theme.primaryColor
                 inputMethodHints: Qt.ImhDigitsOnly
-                EnterKey.enabled: text.length > 0 && acceptableInput == true
+                EnterKey.enabled: text.length > 3 && acceptableInput == true
                 EnterKey.onClicked: licencePlate.focus = true
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
             }
             TextField {
                 id: licencePlate
                 width: parent.textWidth
-                label: qsTr("Licence plate")
+                label: qsTr("License plate number")
                 placeholderText: label
                 validator: RegExpValidator { regExp: /^[0-9A-Za-z_-]{1,32}$/ }
                 color: errorHighlight ? Theme.highlightColor : Theme.primaryColor

--- a/qml/pages/CarCreate.qml
+++ b/qml/pages/CarCreate.qml
@@ -94,7 +94,7 @@ Dialog {
                 width: parent.textWidth
                 label: qsTr("Licence plate")
                 placeholderText: label
-                validator: RegExpValidator { regExp: /^[0-9A-Za-z_]{1,32}$/ }
+                validator: RegExpValidator { regExp: /^[0-9A-Za-z_-]{1,32}$/ }
                 color: errorHighlight ? Theme.highlightColor : Theme.primaryColor
                 inputMethodHints: Qt.ImhNoPredictiveText
                 EnterKey.enabled: text.length > 0 && acceptableInput == true

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -87,6 +87,7 @@ Dialog {
                 anchors { left: parent.left; right: parent.right }
                 label: qsTr("License plate number")
                 placeholderText: label
+                validator: RegExpValidator { regExp: /^[0-9A-Za-z_-]{1,32}$/ }
 
                 EnterKey.enabled: text.length > 0 && acceptableInput == true
                 EnterKey.onClicked: currencyInput.focus = true

--- a/qml/pages/Settings.qml
+++ b/qml/pages/Settings.qml
@@ -52,7 +52,7 @@ Dialog {
                 focus: true
                 label: qsTr("Car manufacturer")
                 placeholderText: label
-
+                validator: RegExpValidator { regExp: /^[0-9A-Za-z_-]{1,32}$/ }
                 EnterKey.enabled: text.length > 0 && acceptableInput == true
                 EnterKey.onClicked: modelInput.focus = true
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
@@ -63,6 +63,7 @@ Dialog {
                 anchors { left: parent.left; right: parent.right }
                 label: qsTr("Car model")
                 placeholderText: label
+                validator: RegExpValidator { regExp: /^[0-9A-Za-z_-]{1,32}$/ }
 
                 EnterKey.enabled: text.length > 0 && acceptableInput == true
                 EnterKey.onClicked: yearInput.focus = true
@@ -72,12 +73,12 @@ Dialog {
             TextField {
                 id: yearInput
                 anchors { left: parent.left; right: parent.right }
-                label: qsTr("Model year")
+                label: qsTr("Car manufacture year")
                 placeholderText: label
                 validator: IntValidator { bottom: 1000; top: 9999 }
                 inputMethodHints: Qt.ImhDigitsOnly
 
-                EnterKey.enabled: text.length > 4 && acceptableInput == true
+                EnterKey.enabled: text.length > 3 && acceptableInput == true
                 EnterKey.onClicked: licensePlateInput.focus = true
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"
             }

--- a/qml/pages/Statistics.qml
+++ b/qml/pages/Statistics.qml
@@ -35,6 +35,7 @@ Page {
     property int beginIndex: manager.car.beginIndex
     property int endIndex: manager.car.endIndex
     property real distanceunitfactor: 1
+    property real distanceunit
 
     Component.onCompleted: {
         distanceunit = manager.car.distanceunity


### PR DESCRIPTION
Bugfix: Statistics page chart was not being visible after swiping the app to background and reactivating it.
Consistency: Settings page and Create Car page now have identical validators and field names.