### PR TITLE
Fixes for TiremountEdit

### DIFF
--- a/qml/pages/TiremountEdit.qml
+++ b/qml/pages/TiremountEdit.qml
@@ -27,7 +27,9 @@ Dialog {
     property TireMount tireMount
     property date mountDate
     property date unmountDate
+    property real distanceunitfactor : 1.0
     allowedOrientations: Orientation.All
+
     SilicaFlickable {
         VerticalScrollDecorator {}
 
@@ -110,8 +112,8 @@ Dialog {
     canAccept: mountDistance.acceptableInput && unmountDistance.acceptableInput
 
     onOpened: {
-        distanceunit = manager.car.distanceUnit
-        if(distanceunit == "mi" )
+        var distanceunit = manager.car.distanceUnit
+        if(distanceunit === "mi" )
         {
             distanceunitfactor = 1.609
         }

--- a/qml/pages/TiremountView.qml
+++ b/qml/pages/TiremountView.qml
@@ -55,7 +55,7 @@ Page {
             menu: ContextMenu {
                 MenuItem {
                     text: qsTr("Modify")
-                    onClicked: pageStack.push(Qt.resolvedUrl("TiremountEdit.qml"), { tirmount: model.modelData })
+                    onClicked: pageStack.push(Qt.resolvedUrl("TiremountEdit.qml"), { tireMount: model.modelData })
                 }
             }
 

--- a/translations/de_DE.ts
+++ b/translations/de_DE.ts
@@ -1143,17 +1143,17 @@
 <context>
     <name>TiremountEdit</name>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="43"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="45"/>
         <source>Modify Tire Mount</source>
         <translation>Reifenmotage bearbeiten</translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="59"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="61"/>
         <source>Mount date</source>
         <translation>Montage Datum</translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="92"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="94"/>
         <source>Unmount date</source>
         <translation>Demontage Datum</translation>
     </message>

--- a/translations/fi_FI.ts
+++ b/translations/fi_FI.ts
@@ -1097,7 +1097,7 @@
     <message>
         <location filename="../qml/pages/TireView.qml" line="54"/>
         <source>Tire List</source>
-        <translation>Renkassarjat</translation>
+        <translation>Rengassarjat</translation>
     </message>
     <message>
         <location filename="../qml/pages/TireView.qml" line="68"/>
@@ -1107,7 +1107,7 @@
     <message>
         <location filename="../qml/pages/TireView.qml" line="73"/>
         <source>Untrash</source>
-        <translatorcomment>Return tires from trash to storage, ready to be installed agian.</translatorcomment>
+        <translatorcomment>Return tires from trash to storage, ready to be installed again.</translatorcomment>
         <translation>Palauta varastoon</translation>
     </message>
     <message>
@@ -1144,17 +1144,17 @@
 <context>
     <name>TiremountEdit</name>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="43"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="45"/>
         <source>Modify Tire Mount</source>
         <translation>Muokkaa rengasasennusta</translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="59"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="61"/>
         <source>Mount date</source>
         <translation>Asennuspäivämäärä</translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="92"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="94"/>
         <source>Unmount date</source>
         <translation>Varastointipäivämäärä</translation>
     </message>

--- a/translations/fr_FR.ts
+++ b/translations/fr_FR.ts
@@ -1143,17 +1143,17 @@
 <context>
     <name>TiremountEdit</name>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="43"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="45"/>
         <source>Modify Tire Mount</source>
         <translation>Modifier un montage de pneu</translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="59"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="61"/>
         <source>Mount date</source>
         <translation>Date de montage</translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="92"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="94"/>
         <source>Unmount date</source>
         <translation>Date de démontage</translation>
     </message>

--- a/translations/harbour-carbudget.ts
+++ b/translations/harbour-carbudget.ts
@@ -1143,17 +1143,17 @@
 <context>
     <name>TiremountEdit</name>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="43"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="45"/>
         <source>Modify Tire Mount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="59"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="61"/>
         <source>Mount date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="92"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="94"/>
         <source>Unmount date</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/it_IT.ts
+++ b/translations/it_IT.ts
@@ -1143,17 +1143,17 @@
 <context>
     <name>TiremountEdit</name>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="43"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="45"/>
         <source>Modify Tire Mount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="59"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="61"/>
         <source>Mount date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="92"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="94"/>
         <source>Unmount date</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/ru_RU.ts
+++ b/translations/ru_RU.ts
@@ -1143,17 +1143,17 @@
 <context>
     <name>TiremountEdit</name>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="43"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="45"/>
         <source>Modify Tire Mount</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="59"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="61"/>
         <source>Mount date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="92"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="94"/>
         <source>Unmount date</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/sv_SE.ts
+++ b/translations/sv_SE.ts
@@ -1143,17 +1143,17 @@
 <context>
     <name>TiremountEdit</name>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="43"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="45"/>
         <source>Modify Tire Mount</source>
         <translation>Ändra däckmontering</translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="59"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="61"/>
         <source>Mount date</source>
         <translation>Monteringsdatum</translation>
     </message>
     <message>
-        <location filename="../qml/pages/TiremountEdit.qml" line="92"/>
+        <location filename="../qml/pages/TiremountEdit.qml" line="94"/>
         <source>Unmount date</source>
         <translation>Avmonteringsdatum</translation>
     </message>


### PR DESCRIPTION
* Fix a typo in pagestack push data for `TiremountEdit.qml` from `TiremountView.qml`
* Add missing property declaration for `distanceunit`
* Add missing local declaration for `distanceunitfactor`
* Fix a typo in Finnish translations `Renkassarjat => Rengassarjat`