### PR TITLE
Clean up string-number conversions

### DIFF
--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -20,6 +20,7 @@
 
 import QtQuick 2.6
 import Sailfish.Silica 1.0
+import "../js/util.js" as Util
 
 CoverBackground {
     // Show main content only if the car exists
@@ -73,7 +74,7 @@ CoverBackground {
                 if(nullCar)
                     return ""
                 else
-                   ("%1 %2 / 100 %3").arg(manager.car.budget.toLocaleString(Qt.locale(),'f',2)).arg(manager.car.currency).arg(manager.car.distanceUnit)
+                   ("%1 %2 / 100 %3").arg(Util.numberToString(manager.car.budget)).arg(manager.car.currency).arg(manager.car.distanceUnit)
             }
             font.pixelSize: Theme.fontSizeSmall
         }
@@ -84,7 +85,7 @@ CoverBackground {
                 if(nullCar)
                     return ""
                 else
-                    ("%1l / 100%2").arg(manager.car.consumption.toLocaleString(Qt.locale(),'f',2)).arg(manager.car.distanceUnit)
+                    ("%1l / 100%2").arg(Util.numberToString(manager.car.consumption)).arg(manager.car.distanceUnit)
             }
             font.pixelSize: Theme.fontSizeSmall
         }

--- a/qml/js/util.js
+++ b/qml/js/util.js
@@ -1,0 +1,12 @@
+function stringToNumber(value) {
+    return Number.fromLocaleString(Qt.locale(), value)
+}
+
+function numberToString(value, precision) {
+    if (value === undefined || value === "")
+        return undefined
+    if (precision === undefined)
+        return value.toLocaleString(Qt.locale(), 'f', 2)
+    else
+        return value.toLocaleString(Qt.locale(), 'f', precision)
+}

--- a/qml/pages/BudgetView.qml
+++ b/qml/pages/BudgetView.qml
@@ -22,6 +22,7 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import harbour.carbudget 1.0
+import "../js/util.js" as Util
 
 Page {
     allowedOrientations: Orientation.All
@@ -182,7 +183,7 @@ Page {
                     Text {
                         width: 0.5 * parent.width
                         height: parent.height
-                        text : qsTr("Bills: %1%").arg((manager.car.budgetCostTotal*100/manager.car.budgetTotal).toLocaleString(Qt.locale(),'f',2))
+                        text: qsTr("Bills: %1%").arg(Util.numberToString(manager.car.budgetCostTotal * 100 / manager.car.budgetTotal))
                         font.pixelSize: Theme.fontSizeMedium
                         color: Theme.primaryColor
                         horizontalAlignment: Text.AlignLeft
@@ -210,7 +211,7 @@ Page {
                     Text {
                         width: 0.5 * parent.width
                         height: parent.height
-                        text : qsTr("Fuel: %1%").arg((manager.car.budgetFuelTotal*100/manager.car.budgetTotal).toLocaleString(Qt.locale(),'f',2))
+                        text: qsTr("Fuel: %1%").arg(Util.numberToString(manager.car.budgetFuelTotal * 100 / manager.car.budgetTotal))
                         font.pixelSize: Theme.fontSizeMedium
                         color: Theme.primaryColor
                         horizontalAlignment: Text.AlignLeft
@@ -238,7 +239,7 @@ Page {
                     Text {
                         width: 0.5 * parent.width
                         height: parent.height
-                        text : qsTr("Tires: %1%").arg((manager.car.budgetTireTotal*100/manager.car.budgetTotal).toLocaleString(Qt.locale(),'f',2))
+                        text: qsTr("Tires: %1%").arg(Util.numberToString(manager.car.budgetTireTotal * 100 / manager.car.budgetTotal))
                         font.pixelSize: Theme.fontSizeMedium
                         color: Theme.primaryColor
                         horizontalAlignment: Text.AlignLeft
@@ -266,7 +267,7 @@ Page {
                     Text {
                         width: 0.5 * parent.width
                         height: parent.height
-                        text : qsTr("Invest: %1%").arg((manager.car.budgetInvestTotal*100/manager.car.budgetTotal).toLocaleString(Qt.locale(),'f',2))
+                        text: qsTr("Invest: %1%").arg(Util.numberToString(manager.car.budgetInvestTotal * 100 / manager.car.budgetTotal))
                         font.pixelSize: Theme.fontSizeMedium
                         color: Theme.primaryColor
                         horizontalAlignment: Text.AlignLeft
@@ -364,7 +365,7 @@ Page {
                                     }
                                     Text {
                                         width:parent.width/2
-                                        text :  manager.car.fuelTotal.toLocaleString(Qt.locale(),'f',2) + " l"
+                                        text: Util.numberToString(manager.car.fuelTotal) + " l"
                                         font.pixelSize: Theme.fontSizeMedium
                                         color: Theme.primaryColor
                                         horizontalAlignment: Text.AlignRight
@@ -384,11 +385,11 @@ Page {
                                     Text {
                                         width:parent.width/2
                                         text: if ( manager.car.consumptionUnit === 'l/100km') {
-                                            manager.car.consumption.toLocaleString(Qt.locale(),'f',2)+ " l";
+                                            Util.numberToString(manager.car.consumption) + " l";
                                         }
                                         else {
                                             if ( manager.car.consumptionUnit === 'mpg') {
-                                                qsTr("%L1 mpg").arg((consumptionfactor * 1/manager.car.consumption).toLocaleString(Qt.locale(),'f',2))
+                                                qsTr("%L1 mpg").arg(Util.numberToString(consumptionfactor / manager.car.consumption))
                                             }
                                         }
                                         font.pixelSize: Theme.fontSizeMedium
@@ -410,11 +411,11 @@ Page {
                                     Text {
                                         width:parent.width/2
                                         text : if (manager.car.consumptionUnit === 'l/100km') {
-                                            manager.car.consumptionMin.toLocaleString(Qt.locale(),'f',2) + " l"
+                                            Util.numberToString(manager.car.consumptionMin) + " l"
                                         }
                                         else {
                                             if ( manager.car.consumptionUnit === 'mpg') {
-                                                qsTr("%L1 mpg").arg((consumptionfactor * 1/manager.car.consumptionMin).toLocaleString(Qt.locale(),'f',2))
+                                                qsTr("%L1 mpg").arg(Util.numberToString(consumptionfactor / manager.car.consumptionMin))
                                             }
                                         }
                                         font.pixelSize: Theme.fontSizeMedium
@@ -436,11 +437,11 @@ Page {
                                     Text {
                                         width:parent.width/2
                                         text :  if ( manager.car.consumptionUnit === 'l/100km') {
-                                            manager.car.consumptionMax.toLocaleString(Qt.locale(),'f',2) + " l"
+                                            Util.numberToString(manager.car.consumptionMax) + " l"
                                         }
                                         else {
                                             if ( manager.car.consumptionUnit === 'mpg') {
-                                                qsTr("%L1 mpg").arg((consumptionfactor * 1/manager.car.consumptionMax).toLocaleString(Qt.locale(),'f',2))
+                                                qsTr("%L1 mpg").arg(Util.numberToString(consumptionfactor / manager.car.consumptionMax))
                                             }
                                         }
                                         font.pixelSize: Theme.fontSizeMedium
@@ -494,7 +495,7 @@ Page {
                             Text {
                                 anchors.right:parent.right
                                 width:parent.width/2
-                                text : manager.car.budgetFuelTotal.toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency
+                                text: Util.numberToString(manager.car.budgetFuelTotal) + " " + manager.car.currency
                                 font.pixelSize: Theme.fontSizeMedium
                                 color: Theme.primaryColor
                                 horizontalAlignment: Text.AlignRight
@@ -526,7 +527,7 @@ Page {
                             Text {
                                 width:parent.width/2
                                 anchors.right:parent.right
-                                text : manager.car.budgetCostTotal.toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency
+                                text: Util.numberToString(manager.car.budgetCostTotal) + " " + manager.car.currency
                                 font.pixelSize: Theme.fontSizeMedium
                                 color: Theme.primaryColor
                                 horizontalAlignment: Text.AlignRight
@@ -557,7 +558,7 @@ Page {
                             Text {
                                 anchors.right:parent.right
                                 width:parent.width/2
-                                text : manager.car.budgetTireTotal.toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency
+                                text: Util.numberToString(manager.car.budgetTireTotal) + " " + manager.car.currency
                                 font.pixelSize: Theme.fontSizeMedium
                                 color: Theme.primaryColor
                                 horizontalAlignment: Text.AlignRight
@@ -588,7 +589,7 @@ Page {
                             Text {
                                 anchors.right:parent.right
                                 width:parent.width/2
-                                text : manager.car.budgetInvestTotal.toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency
+                                text: Util.numberToString(manager.car.budgetInvestTotal) + " " + manager.car.currency
                                 font.pixelSize: Theme.fontSizeMedium
                                 color: Theme.primaryColor
                                 horizontalAlignment: Text.AlignRight
@@ -608,7 +609,7 @@ Page {
                         }
                         Text {
                             width:parent.width/2
-                            text : manager.car.budgetTotal.toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency
+                            text: Util.numberToString(manager.car.budgetTotal) + " " + manager.car.currency
                             font.pixelSize: Theme.fontSizeMedium
                             color: Theme.primaryColor
                             horizontalAlignment: Text.AlignRight
@@ -653,7 +654,7 @@ Page {
                             Text {
                                 width:parent.width/2
                                 anchors.right:parent.right
-                                text : (manager.car.budgetFuel*distanceunitfactor).toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency
+                                text: Util.numberToString(manager.car.budgetFuel * distanceunitfactor) + " " + manager.car.currency
                                 font.pixelSize: Theme.fontSizeMedium
                                 color: Theme.primaryColor
                                 horizontalAlignment: Text.AlignRight
@@ -685,7 +686,7 @@ Page {
                             Text {
                                 width:parent.width/2
                                 anchors.right:parent.right
-                                text : (manager.car.budgetCost*distanceunitfactor).toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency
+                                text: Util.numberToString(manager.car.budgetCost * distanceunitfactor) + " " + manager.car.currency
                                 font.pixelSize: Theme.fontSizeMedium
                                 color: Theme.primaryColor
                                 horizontalAlignment: Text.AlignRight
@@ -717,7 +718,7 @@ Page {
                             Text {
                                 width:parent.width/2
                                 anchors.right:parent.right
-                                text : (manager.car.budgetTire*distanceunitfactor).toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency
+                                text: Util.numberToString(manager.car.budgetTire * distanceunitfactor) + " " + manager.car.currency
                                 font.pixelSize: Theme.fontSizeMedium
                                 color: Theme.primaryColor
                                 horizontalAlignment: Text.AlignRight
@@ -749,7 +750,7 @@ Page {
                             Text {
                                 width:parent.width/2
                                 anchors.right:parent.right
-                                text : (manager.car.budgetInvest*distanceunitfactor).toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency
+                                text: Util.numberToString(manager.car.budgetInvest * distanceunitfactor) + " " + manager.car.currency
                                 font.pixelSize: Theme.fontSizeMedium
                                 color: Theme.primaryColor
                                 horizontalAlignment: Text.AlignRight
@@ -769,7 +770,7 @@ Page {
                         }
                         Text {
                             width:parent.width/2
-                            text : (manager.car.budget*distanceunitfactor).toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency
+                            text: Util.numberToString(manager.car.budget * distanceunitfactor) + " " + manager.car.currency
                             font.pixelSize: Theme.fontSizeMedium
                             color: Theme.primaryColor
                             horizontalAlignment: Text.AlignRight

--- a/qml/pages/CarEntry.qml
+++ b/qml/pages/CarEntry.qml
@@ -21,7 +21,7 @@
 
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-
+import "../js/util.js" as Util
 
 Page {
     id: carEntryPage
@@ -92,20 +92,20 @@ Page {
                 x: Theme.paddingLarge
                 text:
                     if ( manager.car.consumptionUnit === "l/100km" ) {
-                        qsTr("Consumption: %L1 l/100km").arg(manager.car.consumption.toLocaleString(Qt.locale(),'f',2))
+                        qsTr("Consumption: %L1 l/100km").arg(Util.numberToString(manager.car.consumption))
                     }
                     else if ( manager.car.consumptionUnit === "mpg" ) {
-                        qsTr("Consumption: %L1 mpg").arg((consumptionfactor * 1/manager.car.consumption).toLocaleString(Qt.locale(),'f',2))
+                        qsTr("Consumption: %L1 mpg").arg(Util.numberToString(consumptionfactor / manager.car.consumption))
                     }
             }
             Label {
                 x: Theme.paddingLarge
                 text:
                     if ( manager.car.consumptionUnit === "l/100km" ) {
-                        qsTr("Last: %L1 l/100km").arg(manager.car.consumptionLast.toLocaleString(Qt.locale(),'f',2))
+                        qsTr("Last: %L1 l/100km").arg(Util.numberToString(manager.car.consumptionLast))
                     }
                     else if ( manager.car.consumptionUnit === "mpg" ) {
-                        qsTr("Last: %L1 mpg").arg(((consumptionfactor * 1/manager.car.consumptionLast)).toLocaleString(Qt.locale(),'f',2))
+                        qsTr("Last: %L1 mpg").arg(Util.numberToString(consumptionfactor / manager.car.consumptionLast))
                     }
                 color: {
                     if(manager.car.consumptionLast === 0) return Theme.primaryColor

--- a/qml/pages/ConsumptionStatistics.qml
+++ b/qml/pages/ConsumptionStatistics.qml
@@ -21,6 +21,7 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import harbour.carbudget 1.0
+import "../js/util.js" as Util
 
 Page {
     allowedOrientations: Orientation.All
@@ -77,11 +78,11 @@ Page {
                     Text {
                         width:parent.width/2
                         text : if ( manager.car.consumptionUnit === 'l/100km') {
-                            manager.car.budget_consumption_byType(model.modelData.id).toLocaleString(Qt.locale(),'f',2) + " l";
+                            Util.numberToString(manager.car.budget_consumption_byType(model.modelData.id)) + " l";
                         }
                         else {
                             if ( manager.car.consumptionUnit === 'mpg') {
-                                qsTr("%L1 mpg").arg((consumptionfactor * 1/manager.car.budget_consumption_byType(model.modelData.id)).toLocaleString(Qt.locale(),'f',2));
+                                qsTr("%L1 mpg").arg(Util.numberToString(consumptionfactor / manager.car.budget_consumption_byType(model.modelData.id)));
                             }
                         }
                         font.family: "monospaced"
@@ -103,11 +104,11 @@ Page {
                     Text {
                         width:parent.width/2
                         text : if ( manager.car.consumptionUnit === 'l/100km') {
-                            manager.car.budget_consumption_min_byType(model.modelData.id).toLocaleString(Qt.locale(),'f',2) + " l";
+                            Util.numberToString(manager.car.budget_consumption_min_byType(model.modelData.id)) + " l";
                         }
                         else {
                             if ( manager.car.consumptionUnit === 'mpg') {
-                                qsTr("%L1 mpg").arg((consumptionfactor * 1/manager.car.budget_consumption_min_byType(model.modelData.id)).toLocaleString(Qt.locale(),'f',2));
+                                qsTr("%L1 mpg").arg(Util.numberToString(consumptionfactor / manager.car.budget_consumption_min_byType(model.modelData.id)));
                             }
                         }
                         font.family: "monospaced"
@@ -129,11 +130,11 @@ Page {
                     Text {
                         width:parent.width/2
                         text : if ( manager.car.consumptionUnit === 'l/100km') {
-                            manager.car.budget_consumption_max_byType(model.modelData.id).toLocaleString(Qt.locale(),'f',2) + " l";
+                            Util.numberToString(manager.car.budget_consumption_max_byType(model.modelData.id)) + " l";
                         }
                         else {
                             if ( manager.car.consumptionUnit === 'mpg') {
-                                qsTr("%L1 mpg").arg((consumptionfactor * 1/manager.car.budget_consumption_max_byType(model.modelData.id)).toLocaleString(Qt.locale(),'f',2));
+                                qsTr("%L1 mpg").arg(Util.numberToString(consumptionfactor / manager.car.budget_consumption_max_byType(model.modelData.id)));
                             }
                         }
                         font.family: "monospaced"

--- a/qml/pages/CostEntry.qml
+++ b/qml/pages/CostEntry.qml
@@ -21,7 +21,7 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import harbour.carbudget 1.0
-
+import "../js/util.js" as Util
 
 Dialog {
     property Cost cost
@@ -143,7 +143,7 @@ Dialog {
             kminput.text = (cost.distance / distanceunitfactor)
             costType = cost.costType
             descinput.text = cost.description
-            costinput.text = cost.cost.toLocaleString(Qt.locale(),'f',2)
+            costinput.text = Util.numberToString(cost.cost)
             for(var i=0; i<costTypeslistrepeater.count; i++)
             {
                 if(costTypeslistrepeater.itemAt(i).dbid === cost.costType)
@@ -159,13 +159,13 @@ Dialog {
     onAccepted: {
         if(cost == undefined)
         {
-            Number.fromLocaleString(Qt.locale(), myInputField.text)
+            Util.stringToNumber(myInputField.text)
             manager.car.addNewCost(
                 cost_date,
                 kminput.text * distanceunitfactor,
                 costType,
                 descinput.text,
-                Number.fromLocaleString(Qt.locale(), costinput.text)
+                Util.stringToNumber(costinput.text)
             )
         }
         else
@@ -174,7 +174,7 @@ Dialog {
             cost.distance = kminput.text * distanceunitfactor
             cost.costType = costType
             cost.description = descinput.text
-            cost.cost = Number.fromLocaleString(Qt.locale(), costinput.text)
+            cost.cost = Util.stringToNumber(costinput.text)
             cost.save()
         }
     }

--- a/qml/pages/CostEntry.qml
+++ b/qml/pages/CostEntry.qml
@@ -159,7 +159,14 @@ Dialog {
     onAccepted: {
         if(cost == undefined)
         {
-            manager.car.addNewCost(cost_date,kminput.text * distanceunitfactor,costType,descinput.text,costinput.text.replace(",","."))
+            Number.fromLocaleString(Qt.locale(), myInputField.text)
+            manager.car.addNewCost(
+                cost_date,
+                kminput.text * distanceunitfactor,
+                costType,
+                descinput.text,
+                Number.fromLocaleString(Qt.locale(), costinput.text)
+            )
         }
         else
         {
@@ -167,7 +174,7 @@ Dialog {
             cost.distance = kminput.text * distanceunitfactor
             cost.costType = costType
             cost.description = descinput.text
-            cost.cost = costinput.text.replace(",",".")
+            cost.cost = Number.fromLocaleString(Qt.locale(), costinput.text)
             cost.save()
         }
     }

--- a/qml/pages/CostEntryView.qml
+++ b/qml/pages/CostEntryView.qml
@@ -21,7 +21,7 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import harbour.carbudget 1.0
-
+import "../js/util.js" as Util
 
 Page {
         allowedOrientations: Orientation.All
@@ -137,7 +137,7 @@ Page {
                         width:(parent.width-parent.spacing)/2
                     }
                     Text {
-                        text: cost.cost.toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency
+                        text: Util.numberToString(cost.cost) + " " + manager.car.currency
                         font.family: Theme.fontFamily
                         font.pixelSize: Theme.fontSizeMedium
                         color: Theme.primaryColor

--- a/qml/pages/CostStatistics.qml
+++ b/qml/pages/CostStatistics.qml
@@ -21,6 +21,7 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import harbour.carbudget 1.0
+import "../js/util.js" as Util
 
 Page {
     allowedOrientations: Orientation.All
@@ -127,7 +128,7 @@ Page {
                     }
                     Text {
                         width:parent.width/2
-                        text : model.total.toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency
+                        text: Util.numberToString(model.total) + " " + manager.car.currency
                         font.family: "monospaced"
                         font.pixelSize: Theme.fontSizeMedium
                         color: Theme.primaryColor

--- a/qml/pages/CostView.qml
+++ b/qml/pages/CostView.qml
@@ -21,6 +21,7 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import harbour.carbudget 1.0
+import "../js/util.js" as Util
 
 Page {
     property string filter: ""
@@ -141,7 +142,7 @@ Page {
                         id: tPrice
                         anchors.top: tDate.bottom
                         anchors.right: tDate.right
-                        text: model.modelData.cost.toLocaleString(Qt.locale(),'f',2) + " " + manager.car.currency;
+                        text: Util.numberToString(model.modelData.cost) + " " + manager.car.currency;
                         font.family: Theme.fontFamily
                         font.pixelSize: Theme.fontSizeExtraSmall
                         color: Theme.secondaryColor

--- a/qml/pages/TankEntry.qml
+++ b/qml/pages/TankEntry.qml
@@ -21,7 +21,7 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import harbour.carbudget 1.0
-
+import "../js/util.js" as Util
 
 Dialog {
     property Tank tank
@@ -126,7 +126,8 @@ Dialog {
                 anchors { left: parent.left; right: parent.right }
                 validator: DoubleValidator { bottom: 0; top: 99999999 }
                 readOnly: true
-                text:  (Number.fromLocaleString(Qt.locale(), priceinput.text) / Number.fromLocaleString(Qt.locale(), quantityinput.text)).toLocaleString(Qt.locale(),'f',3) || 0
+                property var _unitPrice: Util.stringToNumber(priceinput.text) / Util.stringToNumber(quantityinput.text)
+                text: (_unitPrice > 0 && _unitPrice < Infinity) ? Util.numberToString(_unitPrice, 3) : Util.numberToString(0, 3)
             }
             ComboBox {
                 id: cbfuelType
@@ -209,8 +210,8 @@ Dialog {
         {
             tank_date = tank.date
             kminput.text = (tank.distance / distanceunitfactor).toFixed(0)
-            quantityinput.text = tank.quantity.toLocaleString(Qt.locale(),'f',2)
-            priceinput.text = tank.price.toLocaleString(Qt.locale(),'f',2)
+            quantityinput.text = Util.numberToString(tank.quantity)
+            priceinput.text = Util.numberToString(tank.price)
             fullinput.checked = tank.full
             missedinput.checked = tank.missed
             fuelType = tank.fuelType
@@ -263,8 +264,8 @@ Dialog {
             manager.car.addNewTank(
                 tank_date,
                 kminput.text * distanceunitfactor,
-                Number.fromLocaleString(Qt.locale(), quantityinput.text),
-                Number.fromLocaleString(Qt.locale(), priceinput.text),
+                Util.stringToNumber(quantityinput.text),
+                Util.stringToNumber(priceinput.text),
                 fullinput.checked,
                 missedinput.checked,
                 fuelType,
@@ -282,8 +283,8 @@ Dialog {
                 tank,
                 tank_date,
                 kminput.text * distanceunitfactor,
-                Number.fromLocaleString(Qt.locale(), quantityinput.text),
-                Number.fromLocaleString(Qt.locale(), priceinput.text),
+                Util.stringToNumber(quantityinput.text),
+                Util.stringToNumber(priceinput.text),
                 fullinput.checked,
                 missedinput.checked,
                 fuelType,

--- a/qml/pages/TankEntry.qml
+++ b/qml/pages/TankEntry.qml
@@ -126,7 +126,7 @@ Dialog {
                 anchors { left: parent.left; right: parent.right }
                 validator: DoubleValidator { bottom: 0; top: 99999999 }
                 readOnly: true
-                text:  (priceinput.text.replace(",",".") / quantityinput.text.replace(",",".")).toLocaleString(Qt.locale(),'f',3) || 0
+                text:  (Number.fromLocaleString(Qt.locale(), priceinput.text) / Number.fromLocaleString(Qt.locale(), quantityinput.text)).toLocaleString(Qt.locale(),'f',3) || 0
             }
             ComboBox {
                 id: cbfuelType
@@ -260,7 +260,17 @@ Dialog {
     onAccepted: {
         if(tank == undefined)
         {
-            manager.car.addNewTank(tank_date,kminput.text * distanceunitfactor,quantityinput.text.replace(",","."),priceinput.text.replace(",","."),fullinput.checked, missedinput.checked, fuelType, station, noteinput.text)
+            manager.car.addNewTank(
+                tank_date,
+                kminput.text * distanceunitfactor,
+                Number.fromLocaleString(Qt.locale(), quantityinput.text),
+                Number.fromLocaleString(Qt.locale(), priceinput.text),
+                fullinput.checked,
+                missedinput.checked,
+                fuelType,
+                station,
+                noteinput.text
+            )
         }
         else
         {
@@ -268,7 +278,18 @@ Dialog {
             tank.distance = kminput.text * distanceunitfactor
             tank.full = fullinput.checked
             tank.missed = missedinput.checked
-            manager.car.modifyTank(tank, tank_date,kminput.text * distanceunitfactor,quantityinput.text.replace(",","."),priceinput.text.replace(",","."),fullinput.checked, missedinput.checked, fuelType, station, noteinput.text)
+            manager.car.modifyTank(
+                tank,
+                tank_date,
+                kminput.text * distanceunitfactor,
+                Number.fromLocaleString(Qt.locale(), quantityinput.text),
+                Number.fromLocaleString(Qt.locale(), priceinput.text),
+                fullinput.checked,
+                missedinput.checked,
+                fuelType,
+                station,
+                noteinput.text
+            )
         }
     }
 }

--- a/qml/pages/TankEntryView.qml
+++ b/qml/pages/TankEntryView.qml
@@ -21,7 +21,7 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import harbour.carbudget 1.0
-
+import "../js/util.js" as Util
 
 Page {
         allowedOrientations: Orientation.All
@@ -124,7 +124,7 @@ Page {
                     width:(parent.width-parent.spacing)/2
                 }
                 Text {
-                    text: tank.quantity.toLocaleString(Qt.locale(),'f',2)
+                    text: Util.numberToString(tank.quantity)
                     font.family: Theme.fontFamily
                     font.pixelSize: Theme.fontSizeMedium
                     color: Theme.primaryColor
@@ -146,7 +146,7 @@ Page {
                     width:(parent.width-parent.spacing)/2
                 }
                 Text {
-                    text: tank.price.toLocaleString(Qt.locale(),'f',2)
+                    text: Util.numberToString(tank.price)
                     font.family: Theme.fontFamily
                     font.pixelSize: Theme.fontSizeMedium
                     color: Theme.primaryColor
@@ -168,7 +168,7 @@ Page {
                     width:(parent.width-parent.spacing)/2
                 }
                 Text {
-                    text: (tank.price / tank.quantity).toLocaleString(Qt.locale(),'f',3)
+                    text: Util.numberToString(tank.price / tank.quantity)
                     font.family: Theme.fontFamily
                     font.pixelSize: Theme.fontSizeMedium
                     color: Theme.primaryColor

--- a/qml/pages/TankView.qml
+++ b/qml/pages/TankView.qml
@@ -22,7 +22,7 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import harbour.carbudget 1.0
-
+import "../js/util.js" as Util
 
 Page {
     property string filter: ""
@@ -162,7 +162,7 @@ Page {
                         id: tConsumption
                         anchors.top: tDistance.bottom
                         anchors.left: parent.left
-                        text: model.modelData.pricePerUnit.toLocaleString(Qt.locale(),'f',3)+" "+manager.car.currency + "/l";
+                        text: Util.numberToString(model.modelData.pricePerUnit) + " " + manager.car.currency + "/l";
                         font.family: Theme.fontFamily
                         font.pixelSize: Theme.fontSizeSmall
                         color: Theme.secondaryColor
@@ -176,7 +176,7 @@ Page {
                         anchors.left: tConsumption.right
                         width: parent.width / 5
 
-                        text: model.modelData.quantity.toLocaleString(Qt.locale(),'f',2) + "l"
+                        text: Util.numberToString(model.modelData.quantity) + "l"
                         font.family: Theme.fontFamily
                         font.pixelSize: Theme.fontSizeSmall
                         color: Theme.secondaryColor
@@ -190,7 +190,7 @@ Page {
                         anchors.left: tAmount.right
                         width: parent.width / 5
 
-                        text: model.modelData.price.toLocaleString(Qt.locale(),'f',2)+" "+manager.car.currency;
+                        text: Util.numberToString(model.modelData.price) + " " + manager.car.currency;
                         font.family: Theme.fontFamily
                         font.pixelSize: Theme.fontSizeSmall
                         color: Theme.secondaryColor
@@ -205,10 +205,10 @@ Page {
                         width: parent.width / 5 * 2
 
                         text: if ( manager.car.consumptionUnit === "l/100km") {
-                                  model.modelData.consumption.toLocaleString(Qt.locale(),'f',2)+ "l/100km";
+                                  Util.numberToString(model.modelData.consumption) + "l/100km";
                               }
                               else if ( manager.car.consumptionUnit === "mpg") {
-                                  ("%L1 mpg").arg((consumptionfactor * 1/model.modelData.consumption).toLocaleString(Qt.locale(),'f',2))
+                                  ("%L1 mpg").arg(Util.numberToString(consumptionfactor / model.modelData.consumption))
                               }
 
                         visible: model.modelData.consumption > 0

--- a/qml/pages/TireEntry.qml
+++ b/qml/pages/TireEntry.qml
@@ -147,7 +147,12 @@ Dialog {
             }
         }
     }
-    canAccept: priceinput.acceptableInput && modelinput.acceptableInput && manufacturerinput.acceptableInput && nameinput.acceptableInput && quantityinput.acceptableInput && quantityinput.text > 1
+    canAccept: priceinput.acceptableInput &&
+        modelinput.acceptableInput &&
+        manufacturerinput.acceptableInput &&
+        nameinput.acceptableInput &&
+        quantityinput.acceptableInput &&
+        quantityinput.text > 1
 
     onOpened: {
         if(tire != undefined)
@@ -170,11 +175,27 @@ Dialog {
     onAccepted: {
         if(tire == undefined)
         {
-            manager.car.addNewTire(buy_date,nameinput.text,manufacturerinput.text,modelinput.text,priceinput.text.replace(",","."), quantityinput.text )
+            manager.car.addNewTire(
+                buy_date,
+                nameinput.text,
+                manufacturerinput.text,
+                modelinput.text,
+                Number.fromLocaleString(Qt.locale(), priceinput.text),
+                quantityinput.text
+            )
         }
         else
         {
-            manager.car.modifyTire(tire, buy_date, trash_date, nameinput.text, manufacturerinput.text, modelinput.text, priceinput.text.replace(",","."), quantityinput.text )
+            manager.car.modifyTire(
+                tire,
+                buy_date,
+                trash_date,
+                nameinput.text,
+                manufacturerinput.text,
+                modelinput.text,
+                Number.fromLocaleString(Qt.locale(), priceinput.text),
+                quantityinput.text
+            )
         }
     }
 }

--- a/qml/pages/TireEntry.qml
+++ b/qml/pages/TireEntry.qml
@@ -22,7 +22,7 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import harbour.carbudget 1.0
-
+import "../js/util.js" as Util
 
 Dialog {
     property Tire tire
@@ -159,7 +159,7 @@ Dialog {
         {
             buy_date = tire.buyDate
             trash_date = tire.trashDate
-            priceinput.text = tire.price.toLocaleString(Qt.locale(),'f',2)
+            priceinput.text = Util.numberToString(tire.price)
             quantityinput.text = tire.quantity
             modelinput.text = tire.modelname
             manufacturerinput.text = tire.manufacturer
@@ -180,7 +180,7 @@ Dialog {
                 nameinput.text,
                 manufacturerinput.text,
                 modelinput.text,
-                Number.fromLocaleString(Qt.locale(), priceinput.text),
+                Util.stringToNumber(priceinput.text),
                 quantityinput.text
             )
         }
@@ -193,7 +193,7 @@ Dialog {
                 nameinput.text,
                 manufacturerinput.text,
                 modelinput.text,
-                Number.fromLocaleString(Qt.locale(), priceinput.text),
+                Util.stringToNumber(priceinput.text),
                 quantityinput.text
             )
         }

--- a/qml/pages/TireView.qml
+++ b/qml/pages/TireView.qml
@@ -22,6 +22,7 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import harbour.carbudget 1.0
+import "../js/util.js" as Util
 
 Page {
     allowedOrientations: Orientation.All
@@ -133,7 +134,7 @@ Page {
                         width: parent.width / 2
                     }
                     Text {
-                        text: model.modelData.price.toLocaleString(Qt.locale(),'f',2)+" "+manager.car.currency;
+                        text: Util.numberToString(model.modelData.price) + " " + manager.car.currency;
                         font.bold: model.modelData.mounted
                         font.family: Theme.fontFamily
                         font.pixelSize: Theme.fontSizeSmall


### PR DESCRIPTION
- Remove manually converting strings to numbers
- Use locale for string-to-number and number-to-string conversions
- Create helper functions to keep code cleaner (introduce `util.js`)
- Remove redundant `* 1` from various equations
- Fixup tank entry unit price value calculation and display

I couldn't use function name `toLocaleString` since it was already a declared global, so I used `numberToString` and `stringToNumber` instead.