### PR TITLE
MyBackup and Sailjail support

### DIFF
--- a/harbour-carbudget.desktop
+++ b/harbour-carbudget.desktop
@@ -4,3 +4,6 @@ X-Nemo-Application-Type=silica-qt5
 Name=CarBudget
 Icon=harbour-carbudget
 Exec=harbour-carbudget
+
+[X-HarbourBackup]
+BackupPathList=.config/harbour-carbudget/:.local/share/harbour-carbudget/

--- a/harbour-carbudget.desktop
+++ b/harbour-carbudget.desktop
@@ -7,3 +7,8 @@ Exec=harbour-carbudget
 
 [X-HarbourBackup]
 BackupPathList=.config/harbour-carbudget/:.local/share/harbour-carbudget/
+
+[X-Sailjail]
+Permissions=UserDirs;RemovableMedia
+OrganizationName=harbour-carbudget
+ApplicationName=harbour-carbudget


### PR DESCRIPTION
Adds support for Sailfish OS built-in backup via MyBackup, and adds minimal Sailjail configuration: only user directories and memory card access is needed for import/export functionality.

Fixes #77 and #78